### PR TITLE
Title overwrite plugin

### DIFF
--- a/docsify-plugin-title.js
+++ b/docsify-plugin-title.js
@@ -1,0 +1,12 @@
+(function () {
+  var setFirstWikiTitle = function (hook, vm) {
+    // Invoked on each page load after new HTML has been appended to the DOM
+    hook.doneEach(function () {
+      document.title = "FIRST wiki";
+    });
+  };
+
+  // Add plugin to docsify's plugin array
+  $docsify = $docsify || {};
+  $docsify.plugins = [].concat(setFirstWikiTitle, $docsify.plugins || []);
+})();

--- a/docsify-plugin-title.js
+++ b/docsify-plugin-title.js
@@ -1,5 +1,5 @@
 (function () {
-  var setFirstWikiTitle = function (hook, vm) {
+  var setPageTitle = function (hook, vm) {
     // Invoked on each page load after new HTML has been appended to the DOM
     hook.doneEach(function () {
       document.title = "FIRST wiki";

--- a/index.html
+++ b/index.html
@@ -23,6 +23,9 @@
 <body>
   <div id="app"></div>
 
+  <!-- Overwrite automatic page title -->
+  <script src="docsify-plugin-title.js"></script>
+
   <script>
     // Docsify Configuration (see https://docsify.js.org/#/configuration)
     window.$docsify = {


### PR DESCRIPTION
Uses a Docsify plugin to overwrite page title. (since we use custom html for the sidebar)